### PR TITLE
Fixed runtime notice and added @coverage tags to tests

### DIFF
--- a/src/Json.php
+++ b/src/Json.php
@@ -45,7 +45,7 @@ class Json extends File
      *
      * @throws RuntimeException
      */
-    public static function write($fileName, $data)
+    public static function write($fileName, $data, $mode = 'w')
     {
         $json = json_encode($data, JSON_PRETTY_PRINT);
 
@@ -53,6 +53,6 @@ class Json extends File
             throw new \RuntimeException(json_last_error_msg());
         }
 
-        parent::write($fileName, $json);
+        parent::write($fileName, $json, $mode);
     }
 }

--- a/tests/FileTest.php
+++ b/tests/FileTest.php
@@ -20,6 +20,10 @@ use Desarrolla2\File\File;
  */
 class FileTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @coverage Desarrolla2\File\File::read
+     * @coverage Desarrolla2\File\File::write
+     */
     public function testWriteAndRead()
     {
         $fileName = sys_get_temp_dir().'/'.uniqid(true).'.php.test';

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -20,6 +20,10 @@ use Desarrolla2\File\Json;
  */
 class JsonTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @coverage Desarrolla2\File\Json::read
+     * @coverage Desarrolla2\File\Json::write
+     */
     public function testWriteAndRead()
     {
         $fileName = sys_get_temp_dir().'/'.uniqid(true).'.php.test';


### PR DESCRIPTION
Fixed runtime notice:
Declaration of Desarrolla2\File\Json::write() should be compatible with Desarrolla2\File\File::write($fileName, $data, $mode = 'w')

So added @coverage tags to tests.
